### PR TITLE
remove unnecessary FA in example in English introduction lecture 3

### DIFF
--- a/resources/courses/english/grammar/introduction/lectures/03.md
+++ b/resources/courses/english/grammar/introduction/lectures/03.md
@@ -64,8 +64,8 @@ Notice that the vowels are the five vowels in the Lojban alphabet in order.
 Using one of these words marks that the next sumti will fill the x_1, x_2, x_3, x_4 and x_5 respectively.
 The next sumti after that will be presumed to fill a slot one greater than the previous.
 
-To use an example: _dunda fa do fe ti do_ &ndash; Giving by you of this thing to you. _fa_ marks the x1, the giver, which is "you". _fe_ marks the thing being given, the x_2, which is "this".
-Sumti counting then continues from _fe_, meaning that the last sumti fills x_3, the object receiving.
+To use an example: _dunda fa do ti do_ &ndash; Giving by you of this thing to you. _fa_ marks the x1, the giver, which is "you". _ti_ is the thing being given, the x_2, which is "this".
+Sumti counting then continues, meaning that the last sumti fills x_3, the object receiving.
 
 |Sentence|Equivalent sentence|Possible translation|
 |--------|-------------------|-----------|


### PR DESCRIPTION
the {fe} in {dunda fa do fe ti do} is unnecessary since {fa} has specified x1 and x2 naturally follows x1

I updated the surrounding text as best as I could.
If there are suggestions to improve this text, I'd be happy to hear and apply them.