### PR TITLE
Make fewer assumptions about people's names

### DIFF
--- a/haskell/src/Server/Authentication/Handle.hs
+++ b/haskell/src/Server/Authentication/Handle.hs
@@ -115,9 +115,8 @@ readUserIdentityFromCookies serverConfiguration serverResources = do
             Right True -> do
                 let userIdentifier = UserIdentifier "handle" handle
                 let userPictureUrl = T.empty
-                let userGivenName = T.empty
-                let userFamilyName = T.empty
-                return . Just $ UserIdentity userIdentifier userPictureUrl userGivenName userFamilyName
+                let userName = T.empty
+                return . Just $ UserIdentity userIdentifier userPictureUrl userName
 
 -- * Redis bindings
 registeredHandleKey :: T.Text -> T.Text

--- a/haskell/src/Server/Authentication/Mock.hs
+++ b/haskell/src/Server/Authentication/Mock.hs
@@ -37,9 +37,8 @@ readUserIdentityFromCookies serverConfiguration serverResources = runMaybeT $ do
     if isSignedIn == "true" then do
         let userIdentifier = UserIdentifier "mock" "testuser1"
         let userPictureUrl = "https://lojban.io/favicon.ico"
-        let userGivenName = "Arthur"
-        let userFamilyName = "Dent"
-        return $ UserIdentity userIdentifier userPictureUrl userGivenName userFamilyName
+        let userName = "Arthur Dent"
+        return $ UserIdentity userIdentifier userPictureUrl userName
     else
         mzero
 

--- a/haskell/src/Server/Authentication/OpenID.hs
+++ b/haskell/src/Server/Authentication/OpenID.hs
@@ -51,8 +51,7 @@ instance A.FromJSON Claims where
     parseJSON = A.genericParseJSON A.defaultOptions
 
 data UserInfo = UserInfo
-    { given_name :: T.Text
-    , family_name :: T.Text
+    { name :: T.Text
     , picture :: T.Text
     , email :: T.Text
     } deriving (Generic, Show)
@@ -178,9 +177,8 @@ readUserIdentityFromCookiesForProvider serverConfiguration serverResources known
     -- Build response
     let userIdentifier = UserIdentifier ("openid_" `T.append` (knownProviderIdentifier knownProvider)) (sub claims)
     let userPictureUrl = picture userInfo
-    let userGivenName = given_name userInfo
-    let userFamilyName = family_name userInfo
-    return $ UserIdentity userIdentifier userPictureUrl userGivenName userFamilyName
+    let userName = name userInfo
+    return $ UserIdentity userIdentifier userPictureUrl userName
 
 -- * Helper functions
 getProviderCallbackUri :: KnownOpenIdProvider -> ServerPart URI

--- a/haskell/src/Server/Core.hs
+++ b/haskell/src/Server/Core.hs
@@ -40,8 +40,7 @@ data UserIdentifier = UserIdentifier
 data UserIdentity = UserIdentity
     { userIdentifier :: UserIdentifier
     , userPictureUrl :: T.Text
-    , userGivenName :: T.Text
-    , userFamilyName :: T.Text
+    , userName :: T.Text
     }
 
 data DeckPreferences = DeckPreferences


### PR DESCRIPTION
Before this change it's impossible to log in with a google account that
doesn't have two names on it.